### PR TITLE
add aspiers/lnav-formats to extra format repos

### DIFF
--- a/remote-config.json
+++ b/remote-config.json
@@ -2,6 +2,7 @@
     "format-repos" : [
         "https://github.com/hagfelsh/lnav_formats.git",
         "https://github.com/PaulWay/lnav-formats.git",
-        "https://github.com/penntaylor/lnav-ruby-logger-format.git"
+        "https://github.com/penntaylor/lnav-ruby-logger-format.git",
+        "https://github.com/aspiers/lnav-formats.git"
     ]
 }


### PR DESCRIPTION
I am building and maintaining my own collection of log formats which I already know will be useful to other `lnav` users.